### PR TITLE
Add link to vert.x 3 bindings

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,3 +20,6 @@ Build the API docs locally via
     open target/site/apidocs/index.html
 
 As you can see there are a number of extension methods on the [core Java API](http://vertx.io/api/java/api/) of [vert.x](http://vertx.io/)
+
+### Vert.x 3
+For vert.x 3 bindings see [vertx3-lang-kotlin](https://github.com/cy6erGn0m/vertx3-lang-kotlin)


### PR DESCRIPTION
As there are no updates and this library is vert.x 2 targeted it would be great to put link to newer library

thanks
